### PR TITLE
feat: Ajout de la modification d'une todo

### DIFF
--- a/app/src/components/Todos.vue
+++ b/app/src/components/Todos.vue
@@ -5,7 +5,7 @@
 			<li v-for="todo in filteredTodosArg" :key="todo.name">
 				<input type="checkbox" :id="'checkbox-' + todo.id" v-model=todo.completed>
 				<label :for="'checkbox-' + todo.id">{{todo.id}} | </label>
-				<label v-on:click="update(todo)" v-bind:id="todo.name"> {{todo.name}} </label>
+				<label v-on:click="transform(todo)" v-bind:id="todo.name"> {{todo.name}} </label>
 				<button v-on:click="decrease(todo)" >Supprimer la todo</button>
 
 			</li>
@@ -27,7 +27,7 @@
 <script>
 	import {mapMutations, mapGetters} from "vuex";
 	import {defineComponent} from 'vue';
-
+	import {store} from '../store/store';
 	export default defineComponent({
 		data () {
 			return {
@@ -37,7 +37,28 @@
 			}
 		},
 		methods: {
-			...mapMutations("todolist", ["decrease", "ajouter", "update"])
+			...mapMutations("todolist", ["decrease", "ajouter","update"]),
+
+			transform(todo){
+				let li =  document.getElementById(todo.name);
+				//création d'un input de type texte
+				let input = document.createElement('input');
+				input.setAttribute('type','text');
+				input.setAttribute('value',li.innerText);
+				//affectation d'une fonction à l'input
+				input.addEventListener('keydown',submit);
+				function submit(e){
+					if(e.code == "Enter"){
+						//mise à jour su store
+						store.commit('todolist/update',{index: todo, value: input.value});
+						//mise à jour de l'élément li
+						li.innerText = input.value;
+						input.parentNode.replaceChild(li,input);
+					}
+				}
+				//replace élément par l'input
+				li.parentNode.replaceChild(input,li);
+			}
 		},
 		computed:{
 			...mapGetters("todolist", ["remaining", "hasTodos", "filteredTodos"]),

--- a/app/src/components/Todos.vue
+++ b/app/src/components/Todos.vue
@@ -49,7 +49,7 @@
 				input.addEventListener('keydown', function submit(e){
 					if(e.code == "Enter"){
 						//mise à jour su store
-						store.commit('todolist/update',{index: todo, value: input.value});
+						store.commit('todolist/update',{todo: todo, value: input.value});
 						//mise à jour de l'élément li
 						li.innerText = input.value;
 						input.parentNode.replaceChild(li, input);

--- a/app/src/components/Todos.vue
+++ b/app/src/components/Todos.vue
@@ -5,7 +5,7 @@
 			<li v-for="todo in filteredTodosArg" :key="todo.name">
 				<input type="checkbox" :id="'checkbox-' + todo.id" v-model=todo.completed>
 				<label :for="'checkbox-' + todo.id">{{todo.id}} | </label>
-				<label v-on:click="transform(todo)" v-bind:id="todo.name"> {{todo.name}} </label>
+				<label v-on:click="transform(todo)" v-bind:id="todo.id"> {{todo.name}} </label>
 				<button v-on:click="decrease(todo)" >Supprimer la todo</button>
 
 			</li>
@@ -40,25 +40,24 @@
 			...mapMutations("todolist", ["decrease", "ajouter","update"]),
 
 			transform(todo){
-				let li =  document.getElementById(todo.name);
+				let li = document.getElementById(todo.id);
 				//création d'un input de type texte
 				let input = document.createElement('input');
-				input.setAttribute('type','text');
-				input.setAttribute('value',li.innerText);
+				input.setAttribute('type', 'text');
+				input.setAttribute('value', li.innerText);
 				//affectation d'une fonction à l'input
-				input.addEventListener('keydown',submit);
-				function submit(e){
+				input.addEventListener('keydown', function submit(e){
 					if(e.code == "Enter"){
 						//mise à jour su store
 						store.commit('todolist/update',{index: todo, value: input.value});
 						//mise à jour de l'élément li
 						li.innerText = input.value;
-						input.parentNode.replaceChild(li,input);
+						input.parentNode.replaceChild(li, input);
 					}
-				}
+				})
 				//replace élément par l'input
-				li.parentNode.replaceChild(input,li);
-			}
+				li.parentNode.replaceChild(input, li);
+			},
 		},
 		computed:{
 			...mapGetters("todolist", ["remaining", "hasTodos", "filteredTodos"]),

--- a/app/src/components/Todos.vue
+++ b/app/src/components/Todos.vue
@@ -4,11 +4,10 @@
 		<ul>
 			<li v-for="todo in filteredTodosArg" :key="todo.name">
 				<input type="checkbox" :id="'checkbox-' + todo.id" v-model=todo.completed>
-				<label :for="'checkbox-' + todo.id">{{todo.id}} | Nom de la tache: {{todo.name}} - Completer:{{ (todo.completed == false ? 'non' : 'oui')}} </label>
-
+				<label :for="'checkbox-' + todo.id">{{todo.id}} | </label>
+				<label v-on:click="update(todo)" v-bind:id="todo.name"> {{todo.name}} </label>
 				<button v-on:click="decrease(todo)" >Supprimer la todo</button>
-				<button v-on:click="update(todo)" >Modifier la todo</button>
-				<input type="texte" placeholder="Nom de la tache">
+
 			</li>
 		</ul>
 
@@ -21,6 +20,7 @@
 		<button v-on:click.prevent="filter = 'done' ">tache complétées</button>
 		<button v-on:click.prevent="filter = 'todo' ">tache en cours</button>
 		<button v-on:click.prevent="filter = 'all' ">toute tacher</button>
+
 	</div>
 </template>
 

--- a/app/src/store/todolist/mutations.js
+++ b/app/src/store/todolist/mutations.js
@@ -1,4 +1,9 @@
 export function decrease(state, index){
+	//mise à jour des id suivant la valeur à supprimer
+	for(let i = index.id; i < state.todolist[0].todos.length; i++){
+		state.todolist[0].todos[i].id -= 1;
+	}
+	//suppression
 	state.todolist[0].todos.splice(state.todolist[0].todos.indexOf(index), 1);
 }
 
@@ -12,6 +17,6 @@ export function ajouter(state, {name, completed}){
 	);
 }
 
-export function update(state,{index,value}){
+export function update(state, {index,value}){
 	state.todolist[0].todos[state.todolist[0].todos.indexOf(index)].name = value;
 }

--- a/app/src/store/todolist/mutations.js
+++ b/app/src/store/todolist/mutations.js
@@ -17,6 +17,6 @@ export function ajouter(state, {name, completed}){
 	);
 }
 
-export function update(state, {index,value}){
-	state.todolist[0].todos[state.todolist[0].todos.indexOf(index)].name = value;
+export function update(state, {todo, value}){
+	state.todolist[0].todos[state.todolist[0].todos.indexOf(todo)].name = value;
 }

--- a/app/src/store/todolist/mutations.js
+++ b/app/src/store/todolist/mutations.js
@@ -13,5 +13,21 @@ export function ajouter(state, {name, completed}){
 }
 
 export function update(state, index){
-	state.todolist[0].todos.splice(state.todolist[0].todos.indexOf(index),1);
+	let li =  document.getElementById(state.todolist[0].todos[state.todolist[0].todos.indexOf(index)].name);
+	//création d'un bouton
+	let input = document.createElement('input');
+	input.setAttribute('type','text');
+	input.setAttribute('value',li.innerText);
+	//affectation d'une fonction au bouton
+	input.addEventListener('keydown',submit);
+	function submit(e){
+		if(e.code == "Enter"){
+			//mise à jour de la li et du store
+			li.innerText = input.value;
+			state.todolist[0].todos[state.todolist[0].todos.indexOf(index)].name = input.value;
+			input.parentNode.replaceChild(li,input);
+		}
+	}
+	//replace élément par le bouton
+	li.parentNode.replaceChild(input,li)
 }

--- a/app/src/store/todolist/mutations.js
+++ b/app/src/store/todolist/mutations.js
@@ -12,22 +12,6 @@ export function ajouter(state, {name, completed}){
 	);
 }
 
-export function update(state, index){
-	let li =  document.getElementById(state.todolist[0].todos[state.todolist[0].todos.indexOf(index)].name);
-	//création d'un bouton
-	let input = document.createElement('input');
-	input.setAttribute('type','text');
-	input.setAttribute('value',li.innerText);
-	//affectation d'une fonction au bouton
-	input.addEventListener('keydown',submit);
-	function submit(e){
-		if(e.code == "Enter"){
-			//mise à jour de la li et du store
-			li.innerText = input.value;
-			state.todolist[0].todos[state.todolist[0].todos.indexOf(index)].name = input.value;
-			input.parentNode.replaceChild(li,input);
-		}
-	}
-	//replace élément par le bouton
-	li.parentNode.replaceChild(input,li)
+export function update(state,{index,value}){
+	state.todolist[0].todos[state.todolist[0].todos.indexOf(index)].name = value;
 }


### PR DESCRIPTION
Je ne crois pas que ce soit optimisable (ou alors, avec des choses auquel j'ai pas forcément pensé). ça marche un peu comme sur google keep mais avec un peu moins de style : on clique sur le nom de la todo à modifier, ça la transforme en champ input de type text, une fois qu'on a fini de modiifer notre nom, on appuie sur entré et ça met à jour l'affichage et le store.